### PR TITLE
Move Intel-specific vcpu code to hve

### DIFF
--- a/include/hve/arch/intel_x64/control_register.h
+++ b/include/hve/arch/intel_x64/control_register.h
@@ -30,6 +30,8 @@ namespace eapis
 namespace intel_x64
 {
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE control_register : public base
 {
 public:
@@ -49,7 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    control_register(gsl::not_null<exit_handler_t *> exit_handler);
+    control_register(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/cpuid.h
+++ b/include/hve/arch/intel_x64/cpuid.h
@@ -38,6 +38,8 @@ struct pair_hash {
     }
 };
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE cpuid : public base
 {
 public:
@@ -62,9 +64,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    cpuid(
-        gsl::not_null<exit_handler_t *> exit_handler
-    );
+    cpuid(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/io_instruction.h
+++ b/include/hve/arch/intel_x64/io_instruction.h
@@ -30,6 +30,8 @@ namespace eapis
 namespace intel_x64
 {
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE io_instruction : public base
 {
 public:
@@ -51,10 +53,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    io_instruction(
-        gsl::span<uint8_t> io_bitmaps,
-        gsl::not_null<exit_handler_t *> exit_handler
-    );
+    io_instruction(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/monitor_trap.h
+++ b/include/hve/arch/intel_x64/monitor_trap.h
@@ -30,6 +30,8 @@ namespace eapis
 namespace intel_x64
 {
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE monitor_trap : public base
 {
 public:
@@ -46,7 +48,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    monitor_trap(gsl::not_null<exit_handler_t *> exit_handler);
+    monitor_trap(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/mov_dr.h
+++ b/include/hve/arch/intel_x64/mov_dr.h
@@ -30,6 +30,8 @@ namespace eapis
 namespace intel_x64
 {
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE mov_dr : public base
 {
 public:
@@ -48,7 +50,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    mov_dr(gsl::not_null<exit_handler_t *> exit_handler);
+    mov_dr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/rdmsr.h
+++ b/include/hve/arch/intel_x64/rdmsr.h
@@ -30,6 +30,8 @@ namespace eapis
 namespace intel_x64
 {
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE rdmsr : public base
 {
 public:
@@ -49,10 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    rdmsr(
-        gsl::span<uint8_t> msr_bitmap,
-        gsl::not_null<exit_handler_t *> exit_handler
-    );
+    rdmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/vcpu.h
+++ b/include/hve/arch/intel_x64/vcpu.h
@@ -16,17 +16,20 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <bfvmm/vcpu/arch/intel_x64/vcpu.h>
+#ifndef VCPU_INTEL_X64_EAPIS_H
+#define VCPU_INTEL_X64_EAPIS_H
+
+#include <bfvmm/hve/arch/intel_x64/vcpu/vcpu.h>
 #include <bfvmm/memory_manager/memory_manager.h>
 
-#include "../../../hve/arch/intel_x64/control_register.h"
-#include "../../../hve/arch/intel_x64/cpuid.h"
-#include "../../../hve/arch/intel_x64/io_instruction.h"
-#include "../../../hve/arch/intel_x64/monitor_trap.h"
-#include "../../../hve/arch/intel_x64/mov_dr.h"
-#include "../../../hve/arch/intel_x64/rdmsr.h"
-#include "../../../hve/arch/intel_x64/vpid.h"
-#include "../../../hve/arch/intel_x64/wrmsr.h"
+#include "control_register.h"
+#include "cpuid.h"
+#include "io_instruction.h"
+#include "monitor_trap.h"
+#include "mov_dr.h"
+#include "rdmsr.h"
+#include "vpid.h"
+#include "wrmsr.h"
 
 namespace eapis
 {
@@ -35,6 +38,7 @@ namespace intel_x64
 
 class vcpu : public bfvmm::intel_x64::vcpu
 {
+
 public:
 
     /// Default Constructor
@@ -42,9 +46,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
-        bfvmm::intel_x64::vcpu{id}
-    { }
+    vcpu(vcpuid::type id);
 
     /// Destructor
     ///
@@ -67,8 +69,7 @@ public:
     /// @return Returns the CR object stored in the vCPU if CR trapping is
     ///     enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<control_register *> control_register()
-    { return m_control_register.get(); }
+    gsl::not_null<control_register *> control_register();
 
     /// Enable Write CR0 Exiting
     ///
@@ -76,11 +77,7 @@ public:
     /// @ensures
     ///
     void enable_wrcr0_exiting(
-        vmcs_n::value_type mask, vmcs_n::value_type shadow)
-    {
-        check_crall();
-        m_control_register->enable_wrcr0_exiting(mask, shadow);
-    }
+        vmcs_n::value_type mask, vmcs_n::value_type shadow);
 
     /// Enable Write CR4 Exiting
     ///
@@ -88,77 +85,49 @@ public:
     /// @ensures
     ///
     void enable_wrcr4_exiting(
-        vmcs_n::value_type mask, vmcs_n::value_type shadow)
-    {
-        check_crall();
-        m_control_register->enable_wrcr4_exiting(mask, shadow);
-    }
+        vmcs_n::value_type mask, vmcs_n::value_type shadow);
 
     /// Add Write CR0 Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_wrcr0_handler(control_register::handler_delegate_t &&d)
-    {
-        check_crall();
-        m_control_register->add_wrcr0_handler(std::move(d));
-    }
+    void add_wrcr0_handler(control_register::handler_delegate_t &&d);
 
     /// Add Read CR3 Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_rdcr3_handler(control_register::handler_delegate_t &&d)
-    {
-        check_rdcr3();
-        m_control_register->add_rdcr3_handler(std::move(d));
-    }
+    void add_rdcr3_handler(control_register::handler_delegate_t &&d);
 
     /// Add Write CR3 Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_wrcr3_handler(control_register::handler_delegate_t &&d)
-    {
-        check_wrcr3();
-        m_control_register->add_wrcr3_handler(std::move(d));
-    }
+    void add_wrcr3_handler(control_register::handler_delegate_t &&d);
 
     /// Add Write CR4 Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_wrcr4_handler(control_register::handler_delegate_t &&d)
-    {
-        check_crall();
-        m_control_register->add_wrcr4_handler(std::move(d));
-    }
+    void add_wrcr4_handler(control_register::handler_delegate_t &&d);
 
     /// Add Read CR8 Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_rdcr8_handler(control_register::handler_delegate_t &&d)
-    {
-        check_rdcr8();
-        m_control_register->add_rdcr8_handler(std::move(d));
-    }
+    void add_rdcr8_handler(control_register::handler_delegate_t &&d);
 
     /// Add Write CR8 Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_wrcr8_handler(control_register::handler_delegate_t &&d)
-    {
-        check_wrcr8();
-        m_control_register->add_wrcr8_handler(std::move(d));
-    }
+    void add_wrcr8_handler(control_register::handler_delegate_t &&d);
 
     //--------------------------------------------------------------------------
     // CPUID
@@ -172,8 +141,7 @@ public:
     /// @return Returns the CPUID object stored in the vCPU if CPUID trapping is
     ///     enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<cpuid *> cpuid()
-    { return m_cpuid.get(); }
+    gsl::not_null<cpuid *> cpuid();
 
     /// Add CPUID Handler
     ///
@@ -181,14 +149,7 @@ public:
     /// @ensures
     ///
     void add_cpuid_handler(
-        cpuid::leaf_t leaf, cpuid::subleaf_t subleaf, cpuid::handler_delegate_t &&d)
-    {
-        if (!m_cpuid) {
-            m_cpuid = std::make_unique<eapis::intel_x64::cpuid>(this->exit_handler());
-        }
-
-        m_cpuid->add_handler(leaf, subleaf, std::move(d));
-    }
+        cpuid::leaf_t leaf, cpuid::subleaf_t subleaf, cpuid::handler_delegate_t &&d);
 
     //--------------------------------------------------------------------------
     // IO Instruction
@@ -202,8 +163,7 @@ public:
     /// @return Returns the IO Instruction object stored in the vCPU if IO
     ///     Instruction trapping is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<io_instruction *> io_instruction()
-    { return m_io_instruction.get(); }
+    gsl::not_null<io_instruction *> io_instruction();
 
     /// Add CPUID Handler
     ///
@@ -213,19 +173,7 @@ public:
     void add_io_instruction_handler(
         vmcs_n::value_type port,
         io_instruction::handler_delegate_t &&in_d,
-        io_instruction::handler_delegate_t &&out_d)
-    {
-        check_io_bitmaps();
-
-        if (!m_io_instruction) {
-            m_io_instruction = std::make_unique<eapis::intel_x64::io_instruction>(
-                gsl::make_span(m_io_bitmaps.get(), ::x64::page_size * 2),
-                this->exit_handler()
-            );
-        }
-
-        m_io_instruction->add_handler(port, std::move(in_d), std::move(out_d));
-    }
+        io_instruction::handler_delegate_t &&out_d);
 
     //--------------------------------------------------------------------------
     // Monitor Trap
@@ -239,30 +187,21 @@ public:
     /// @return Returns the Monitor Trap object stored in the vCPU if Monitor
     ///     Trap is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<monitor_trap *> monitor_trap()
-    { return m_monitor_trap.get(); }
+    gsl::not_null<monitor_trap *> monitor_trap();
 
     /// Add Monitor Trap Flag Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_monitor_trap_handler(monitor_trap::handler_delegate_t &&d)
-    {
-        check_monitor_trap();
-        m_monitor_trap->add_handler(std::move(d));
-    }
+    void add_monitor_trap_handler(monitor_trap::handler_delegate_t &&d);
 
     /// Enable Monitor Trap Flag
     ///
     /// @expects
     /// @ensures
     ///
-    void enable_monitor_trap_flag()
-    {
-        check_monitor_trap();
-        m_monitor_trap->enable();
-    }
+    void enable_monitor_trap_flag();
 
     //--------------------------------------------------------------------------
     // Move DR
@@ -276,22 +215,14 @@ public:
     /// @return Returns the Move DR object stored in the vCPU if Move DR
     ///     trapping is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<mov_dr *> mov_dr()
-    { return m_mov_dr.get(); }
+    gsl::not_null<mov_dr *> mov_dr();
 
     /// Add Move DR Handler
     ///
     /// @expects
     /// @ensures
     ///
-    void add_mov_dr_handler(mov_dr::handler_delegate_t &&d)
-    {
-        if (!m_mov_dr) {
-            m_mov_dr = std::make_unique<eapis::intel_x64::mov_dr>(this->exit_handler());
-        }
-
-        m_mov_dr->add_handler(std::move(d));
-    }
+    void add_mov_dr_handler(mov_dr::handler_delegate_t &&d);
 
     //--------------------------------------------------------------------------
     // Read MSR
@@ -305,16 +236,14 @@ public:
     /// @return Returns the Read MSR object stored in the vCPU if Read MSR
     ///     trapping is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<rdmsr *> rdmsr()
-    { return m_rdmsr.get(); }
+    gsl::not_null<rdmsr *> rdmsr();
 
     /// Pass Through All Read MSR Accesses
     ///
     /// @expects
     /// @ensures
     ///
-    void pass_through_all_rdmsr_accesses()
-    { check_rdmsr(); }
+    void pass_through_all_rdmsr_accesses();
 
     /// Add Read MSR Handler
     ///
@@ -322,11 +251,7 @@ public:
     /// @ensures
     ///
     void add_rdmsr_handler(
-        vmcs_n::value_type msr, rdmsr::handler_delegate_t &&d)
-    {
-        check_rdmsr();
-        m_rdmsr->add_handler(msr, std::move(d));
-    }
+        vmcs_n::value_type msr, rdmsr::handler_delegate_t &&d);
 
     //--------------------------------------------------------------------------
     // VPID
@@ -340,20 +265,14 @@ public:
     /// @return Returns the VPID object stored in the vCPU if VPID trapping is
     ///     enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<vpid *> vpid()
-    { return m_vpid.get(); }
+    gsl::not_null<vpid *> vpid();
 
     /// Enable VPID
     ///
     /// @expects
     /// @ensures
     ///
-    void enable_vpid()
-    {
-        if (!m_vpid) {
-            m_vpid = std::make_unique<eapis::intel_x64::vpid>();
-        }
-    }
+    void enable_vpid();
 
     //--------------------------------------------------------------------------
     // Write MSR
@@ -367,16 +286,14 @@ public:
     /// @return Returns the Write MSR object stored in the vCPU if Write MSR
     ///     trapping is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<wrmsr *> wrmsr()
-    { return m_wrmsr.get(); }
+    gsl::not_null<wrmsr *> wrmsr();
 
     /// Pass Through All Write MSR Accesses
     ///
     /// @expects
     /// @ensures
     ///
-    void pass_through_all_wrmsr_accesses()
-    { check_wrmsr(); }
+    void pass_through_all_wrmsr_accesses();
 
     /// Add Write MSR Handler
     ///
@@ -384,117 +301,38 @@ public:
     /// @ensures
     ///
     void add_wrmsr_handler(
-        vmcs_n::value_type msr, wrmsr::handler_delegate_t &&d)
-    {
-        check_wrmsr();
-        m_wrmsr->add_handler(msr, std::move(d));
-    }
+        vmcs_n::value_type msr, wrmsr::handler_delegate_t &&d);
+
+    /// MSR bitmap
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return A span of the msr_bitmap
+    ///
+    gsl::span<uint8_t> msr_bitmap();
+
+    /// IO bitmaps
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return A span of the io_bitmaps
+    ///
+    gsl::span<uint8_t> io_bitmaps();
 
 private:
 
-    void check_crall()
-    {
-        if (!m_control_register) {
-            m_control_register = std::make_unique<eapis::intel_x64::control_register>(this->exit_handler());
-        }
-    }
-
-    void check_rdcr3()
-    {
-        check_crall();
-
-        if (!m_is_rdcr3_enabled) {
-            m_is_rdcr3_enabled = true;
-            m_control_register->enable_rdcr3_exiting();
-        }
-    }
-
-    void check_wrcr3()
-    {
-        check_crall();
-
-        if (!m_is_wrcr3_enabled) {
-            m_is_wrcr3_enabled = true;
-            m_control_register->enable_wrcr3_exiting();
-        }
-    }
-
-    void check_rdcr8()
-    {
-        check_crall();
-
-        if (!m_is_rdcr8_enabled) {
-            m_is_rdcr8_enabled = true;
-            m_control_register->enable_rdcr8_exiting();
-        }
-    }
-
-    void check_wrcr8()
-    {
-        check_crall();
-
-        if (!m_is_wrcr8_enabled) {
-            m_is_wrcr8_enabled = true;
-            m_control_register->enable_wrcr8_exiting();
-        }
-    }
-
-    void check_io_bitmaps()
-    {
-        using namespace vmcs_n;
-
-        if (!m_io_bitmaps) {
-            m_io_bitmaps = std::make_unique<uint8_t[]>(::x64::page_size * 2);
-
-            address_of_io_bitmap_a::set(g_mm->virtptr_to_physint(&m_io_bitmaps[0x0000]));
-            address_of_io_bitmap_b::set(g_mm->virtptr_to_physint(&m_io_bitmaps[010000]));
-
-            primary_processor_based_vm_execution_controls::use_io_bitmaps::enable();
-        }
-    }
-
-    void check_monitor_trap()
-    {
-        if (!m_monitor_trap) {
-            m_monitor_trap = std::make_unique<eapis::intel_x64::monitor_trap>(this->exit_handler());
-        }
-    }
-
-    void check_msr_bitmap()
-    {
-        using namespace vmcs_n;
-
-        if (!m_msr_bitmap) {
-            m_msr_bitmap = std::make_unique<uint8_t[]>(::x64::page_size);
-
-            address_of_msr_bitmap::set(g_mm->virtptr_to_physint(m_msr_bitmap.get()));
-            primary_processor_based_vm_execution_controls::use_msr_bitmap::enable();
-        }
-    }
-
-    void check_rdmsr()
-    {
-        check_msr_bitmap();
-
-        if (!m_rdmsr) {
-            m_rdmsr = std::make_unique<eapis::intel_x64::rdmsr>(
-                gsl::make_span(m_msr_bitmap.get(), ::x64::page_size),
-                this->exit_handler()
-            );
-        }
-    }
-
-    void check_wrmsr()
-    {
-        check_msr_bitmap();
-
-        if (!m_wrmsr) {
-            m_wrmsr = std::make_unique<eapis::intel_x64::wrmsr>(
-                gsl::make_span(m_msr_bitmap.get(), ::x64::page_size),
-                this->exit_handler()
-            );
-        }
-    }
+    void check_crall();
+    void check_rdcr3();
+    void check_wrcr3();
+    void check_rdcr8();
+    void check_wrcr8();
+    void check_io_bitmaps();
+    void check_monitor_trap();
+    void check_msr_bitmap();
+    void check_rdmsr();
+    void check_wrmsr();
 
 private:
 
@@ -518,3 +356,5 @@ private:
 
 }
 }
+
+#endif

--- a/include/hve/arch/intel_x64/vpid.h
+++ b/include/hve/arch/intel_x64/vpid.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class EXPORT_EAPIS_HVE vpid : public base
+class EXPORT_EAPIS_HVE vpid
 {
 public:
 
@@ -48,7 +48,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    ~vpid() final = default;
+    ~vpid() = default;
 
     /// Get ID
     ///
@@ -57,23 +57,14 @@ public:
     ///
     /// @return Returns the VPID
     ///
-    vmcs_n::value_type id() const noexcept
-    { return m_id; }
+    vmcs_n::value_type id() const noexcept;
 
-public:
-
-    /// Dump Log
-    ///
-    /// Example:
-    /// @code
-    /// this->dump_log();
-    /// @endcode
+    /// Enable
     ///
     /// @expects
     /// @ensures
     ///
-    void dump_log() final
-    { }
+    void enable();
 
 private:
 

--- a/include/hve/arch/intel_x64/wrmsr.h
+++ b/include/hve/arch/intel_x64/wrmsr.h
@@ -30,6 +30,8 @@ namespace eapis
 namespace intel_x64
 {
 
+class vcpu;
+
 class EXPORT_EAPIS_HVE wrmsr : public base
 {
 public:
@@ -49,10 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    wrmsr(
-        gsl::span<uint8_t> msr_bitmap,
-        gsl::not_null<exit_handler_t *> exit_handler
-    );
+    wrmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/integration/arch/intel_x64/control_register/trap_cr0.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr0.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/control_register/trap_cr3.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr3.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/control_register/trap_cr4.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr4.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/control_register/trap_cr8.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr8.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/cpuid/trap_cpuid.cpp
+++ b/integration/arch/intel_x64/cpuid/trap_cpuid.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/io_instruction/trap_in_out.cpp
+++ b/integration/arch/intel_x64/io_instruction/trap_in_out.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/monitor_trap/single_step_cpuid.cpp
+++ b/integration/arch/intel_x64/monitor_trap/single_step_cpuid.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/mov_dr/trap_dr7.cpp
+++ b/integration/arch/intel_x64/mov_dr/trap_dr7.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/rdmsr/trap_rdmsr.cpp
+++ b/integration/arch/intel_x64/rdmsr/trap_rdmsr.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/vpid/enable_vpid.cpp
+++ b/integration/arch/intel_x64/vpid/enable_vpid.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/integration/arch/intel_x64/wrmsr/trap_wrmsr.cpp
+++ b/integration/arch/intel_x64/wrmsr/trap_wrmsr.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 

--- a/src/hve/CMakeLists.txt
+++ b/src/hve/CMakeLists.txt
@@ -24,6 +24,7 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/monitor_trap.cpp
         arch/intel_x64/mov_dr.cpp
         arch/intel_x64/rdmsr.cpp
+        arch/intel_x64/vcpu.cpp
         arch/intel_x64/vpid.cpp
         arch/intel_x64/wrmsr.cpp
     )

--- a/src/hve/arch/intel_x64/control_register.cpp
+++ b/src/hve/arch/intel_x64/control_register.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/control_register.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 namespace eapis
 {
@@ -30,9 +30,9 @@ default_handler(
 { bfignored(vmcs); bfignored(info); return true; }
 
 control_register::control_register(
-    gsl::not_null<exit_handler_t *> exit_handler
+    gsl::not_null<eapis::intel_x64::vcpu *> vcpu
 ) :
-    m_exit_handler{exit_handler}
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/cpuid.cpp
+++ b/src/hve/arch/intel_x64/cpuid.cpp
@@ -17,15 +17,15 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/cpuid.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-cpuid::cpuid(gsl::not_null<exit_handler_t *> exit_handler) :
-    m_exit_handler{exit_handler}
+cpuid::cpuid(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/io_instruction.cpp
+++ b/src/hve/arch/intel_x64/io_instruction.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/io_instruction.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 #include <bfvmm/memory_manager/arch/x64/map_ptr.h>
 
@@ -26,12 +26,9 @@ namespace eapis
 namespace intel_x64
 {
 
-io_instruction::io_instruction(
-    gsl::span<uint8_t> io_bitmaps,
-    gsl::not_null<exit_handler_t *> exit_handler
-) :
-    m_io_bitmaps{io_bitmaps},
-    m_exit_handler{exit_handler}
+io_instruction::io_instruction(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
+    m_io_bitmaps{vcpu->io_bitmaps()},
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/monitor_trap.cpp
+++ b/src/hve/arch/intel_x64/monitor_trap.cpp
@@ -17,15 +17,15 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/monitor_trap.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-monitor_trap::monitor_trap(gsl::not_null<exit_handler_t *> exit_handler) :
-    m_exit_handler{exit_handler}
+monitor_trap::monitor_trap(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/mov_dr.cpp
+++ b/src/hve/arch/intel_x64/mov_dr.cpp
@@ -17,15 +17,15 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/mov_dr.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-mov_dr::mov_dr(gsl::not_null<exit_handler_t *> exit_handler) :
-    m_exit_handler{exit_handler}
+mov_dr::mov_dr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/rdmsr.cpp
+++ b/src/hve/arch/intel_x64/rdmsr.cpp
@@ -17,19 +17,16 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/rdmsr.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-rdmsr::rdmsr(
-    gsl::span<uint8_t> msr_bitmap,
-    gsl::not_null<exit_handler_t *> exit_handler
-) :
-    m_msr_bitmap{msr_bitmap},
-    m_exit_handler{exit_handler}
+rdmsr::rdmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
+    m_msr_bitmap{vcpu->msr_bitmap()},
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/vcpu.cpp
+++ b/src/hve/arch/intel_x64/vcpu.cpp
@@ -1,0 +1,320 @@
+//
+// Bareflank Extended APIs
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfvmm/hve/arch/intel_x64/vcpu/vcpu.h>
+#include <bfvmm/memory_manager/memory_manager.h>
+
+#include <hve/arch/intel_x64/vcpu.h>
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+vcpu::vcpu(vcpuid::type id) :
+    bfvmm::intel_x64::vcpu{id}
+{ }
+
+//--------------------------------------------------------------------------
+// Control Register
+//--------------------------------------------------------------------------
+
+gsl::not_null<control_register *> vcpu::control_register()
+{ return m_control_register.get(); }
+
+void vcpu::enable_wrcr0_exiting(
+    vmcs_n::value_type mask, vmcs_n::value_type shadow)
+{
+    check_crall();
+    m_control_register->enable_wrcr0_exiting(mask, shadow);
+}
+
+void vcpu::enable_wrcr4_exiting(
+    vmcs_n::value_type mask, vmcs_n::value_type shadow)
+{
+    check_crall();
+    m_control_register->enable_wrcr4_exiting(mask, shadow);
+}
+
+void vcpu::add_wrcr0_handler(control_register::handler_delegate_t &&d)
+{
+    check_crall();
+    m_control_register->add_wrcr0_handler(std::move(d));
+}
+
+void vcpu::add_rdcr3_handler(control_register::handler_delegate_t &&d)
+{
+    check_rdcr3();
+    m_control_register->add_rdcr3_handler(std::move(d));
+}
+
+void vcpu::add_wrcr3_handler(control_register::handler_delegate_t &&d)
+{
+    check_wrcr3();
+    m_control_register->add_wrcr3_handler(std::move(d));
+}
+
+void vcpu::add_wrcr4_handler(control_register::handler_delegate_t &&d)
+{
+    check_crall();
+    m_control_register->add_wrcr4_handler(std::move(d));
+}
+
+void vcpu::add_rdcr8_handler(control_register::handler_delegate_t &&d)
+{
+    check_rdcr8();
+    m_control_register->add_rdcr8_handler(std::move(d));
+}
+
+void vcpu::add_wrcr8_handler(control_register::handler_delegate_t &&d)
+{
+    check_wrcr8();
+    m_control_register->add_wrcr8_handler(std::move(d));
+}
+
+//--------------------------------------------------------------------------
+// CPUID
+//--------------------------------------------------------------------------
+
+gsl::not_null<cpuid *> vcpu::cpuid()
+{ return m_cpuid.get(); }
+
+void vcpu::add_cpuid_handler(
+    cpuid::leaf_t leaf, cpuid::subleaf_t subleaf, cpuid::handler_delegate_t &&d)
+{
+    if (!m_cpuid) {
+        m_cpuid = std::make_unique<eapis::intel_x64::cpuid>(this);
+    }
+
+    m_cpuid->add_handler(leaf, subleaf, std::move(d));
+}
+
+//--------------------------------------------------------------------------
+// IO Instruction
+//--------------------------------------------------------------------------
+
+gsl::not_null<io_instruction *> vcpu::io_instruction()
+{ return m_io_instruction.get(); }
+
+void vcpu::add_io_instruction_handler(
+    vmcs_n::value_type port,
+    io_instruction::handler_delegate_t &&in_d,
+    io_instruction::handler_delegate_t &&out_d)
+{
+    check_io_bitmaps();
+
+    if (!m_io_instruction) {
+        m_io_instruction = std::make_unique<eapis::intel_x64::io_instruction>(this);
+    }
+
+    m_io_instruction->add_handler(port, std::move(in_d), std::move(out_d));
+}
+
+//--------------------------------------------------------------------------
+// Monitor Trap
+//--------------------------------------------------------------------------
+
+gsl::not_null<monitor_trap *> vcpu::monitor_trap()
+{ return m_monitor_trap.get(); }
+
+void vcpu::add_monitor_trap_handler(monitor_trap::handler_delegate_t &&d)
+{
+    check_monitor_trap();
+    m_monitor_trap->add_handler(std::move(d));
+}
+
+void vcpu::enable_monitor_trap_flag()
+{
+    check_monitor_trap();
+    m_monitor_trap->enable();
+}
+
+//--------------------------------------------------------------------------
+// Move DR
+//--------------------------------------------------------------------------
+
+gsl::not_null<mov_dr *> vcpu::mov_dr()
+{ return m_mov_dr.get(); }
+
+void vcpu::add_mov_dr_handler(mov_dr::handler_delegate_t &&d)
+{
+    if (!m_mov_dr) {
+        m_mov_dr = std::make_unique<eapis::intel_x64::mov_dr>(this);
+    }
+
+    m_mov_dr->add_handler(std::move(d));
+}
+
+//--------------------------------------------------------------------------
+// Read MSR
+//--------------------------------------------------------------------------
+
+gsl::not_null<rdmsr *> vcpu::rdmsr()
+{ return m_rdmsr.get(); }
+
+void vcpu::pass_through_all_rdmsr_accesses()
+{ check_rdmsr(); }
+
+void vcpu::add_rdmsr_handler(
+    vmcs_n::value_type msr, rdmsr::handler_delegate_t &&d)
+{
+    check_rdmsr();
+    m_rdmsr->add_handler(msr, std::move(d));
+}
+
+//--------------------------------------------------------------------------
+// VPID
+//--------------------------------------------------------------------------
+
+gsl::not_null<vpid *> vcpu::vpid()
+{ return m_vpid.get(); }
+
+void vcpu::enable_vpid()
+{
+    if (!m_vpid) {
+        m_vpid = std::make_unique<eapis::intel_x64::vpid>();
+    }
+}
+
+//--------------------------------------------------------------------------
+// Write MSR
+//--------------------------------------------------------------------------
+
+gsl::not_null<wrmsr *> vcpu::wrmsr()
+{ return m_wrmsr.get(); }
+
+void vcpu::pass_through_all_wrmsr_accesses()
+{ check_wrmsr(); }
+
+void vcpu::add_wrmsr_handler(
+    vmcs_n::value_type msr, wrmsr::handler_delegate_t &&d)
+{
+    check_wrmsr();
+    m_wrmsr->add_handler(msr, std::move(d));
+}
+
+//--------------------------------------------------------------------------
+// Checks
+//--------------------------------------------------------------------------
+
+void vcpu::check_crall()
+{
+    if (!m_control_register) {
+        m_control_register = std::make_unique<eapis::intel_x64::control_register>(this);
+    }
+}
+
+void vcpu::check_rdcr3()
+{
+    check_crall();
+
+    if (!m_is_rdcr3_enabled) {
+        m_is_rdcr3_enabled = true;
+        m_control_register->enable_rdcr3_exiting();
+    }
+}
+
+void vcpu::check_wrcr3()
+{
+    check_crall();
+
+    if (!m_is_wrcr3_enabled) {
+        m_is_wrcr3_enabled = true;
+        m_control_register->enable_wrcr3_exiting();
+    }
+}
+
+void vcpu::check_rdcr8()
+{
+    check_crall();
+
+    if (!m_is_rdcr8_enabled) {
+        m_is_rdcr8_enabled = true;
+        m_control_register->enable_rdcr8_exiting();
+    }
+}
+
+void vcpu::check_wrcr8()
+{
+    check_crall();
+
+    if (!m_is_wrcr8_enabled) {
+        m_is_wrcr8_enabled = true;
+        m_control_register->enable_wrcr8_exiting();
+    }
+}
+
+void vcpu::check_io_bitmaps()
+{
+    using namespace vmcs_n;
+
+    if (!m_io_bitmaps) {
+        m_io_bitmaps = std::make_unique<uint8_t[]>(::x64::page_size * 2);
+
+        address_of_io_bitmap_a::set(g_mm->virtptr_to_physint(&m_io_bitmaps[0x0000]));
+        address_of_io_bitmap_b::set(g_mm->virtptr_to_physint(&m_io_bitmaps[010000]));
+
+        primary_processor_based_vm_execution_controls::use_io_bitmaps::enable();
+    }
+}
+
+void vcpu::check_monitor_trap()
+{
+    if (!m_monitor_trap) {
+        m_monitor_trap = std::make_unique<eapis::intel_x64::monitor_trap>(this);
+    }
+}
+
+void vcpu::check_msr_bitmap()
+{
+    using namespace vmcs_n;
+
+    if (!m_msr_bitmap) {
+        m_msr_bitmap = std::make_unique<uint8_t[]>(::x64::page_size);
+
+        address_of_msr_bitmap::set(g_mm->virtptr_to_physint(m_msr_bitmap.get()));
+        primary_processor_based_vm_execution_controls::use_msr_bitmap::enable();
+    }
+}
+
+void vcpu::check_rdmsr()
+{
+    check_msr_bitmap();
+
+    if (!m_rdmsr) {
+        m_rdmsr = std::make_unique<eapis::intel_x64::rdmsr>(this);
+    }
+}
+
+void vcpu::check_wrmsr()
+{
+    check_msr_bitmap();
+
+    if (!m_wrmsr) {
+        m_wrmsr = std::make_unique<eapis::intel_x64::wrmsr>(this);
+    }
+}
+
+gsl::span<uint8_t> vcpu::msr_bitmap()
+{ return gsl::make_span(m_msr_bitmap.get(), ::x64::page_size); }
+
+gsl::span<uint8_t> vcpu::io_bitmaps()
+{ return gsl::make_span(m_io_bitmaps.get(), ::x64::page_size << 1U); }
+
+}
+}

--- a/src/hve/arch/intel_x64/vpid.cpp
+++ b/src/hve/arch/intel_x64/vpid.cpp
@@ -30,8 +30,13 @@ vpid::vpid()
     m_id = s_id++;
 
     vmcs_n::virtual_processor_identifier::set(m_id);
-    vmcs_n::secondary_processor_based_vm_execution_controls::enable_vpid::enable();
 }
+
+vmcs_n::value_type vpid::id() const noexcept
+{ return m_id; }
+
+void vpid::enable()
+{ vmcs_n::secondary_processor_based_vm_execution_controls::enable_vpid::enable(); }
 
 }
 }

--- a/src/hve/arch/intel_x64/wrmsr.cpp
+++ b/src/hve/arch/intel_x64/wrmsr.cpp
@@ -17,19 +17,16 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/wrmsr.h>
+#include <hve/arch/intel_x64/vcpu.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-wrmsr::wrmsr(
-    gsl::span<uint8_t> msr_bitmap,
-    gsl::not_null<exit_handler_t *> exit_handler
-) :
-    m_msr_bitmap{msr_bitmap},
-    m_exit_handler{exit_handler}
+wrmsr::wrmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
+    m_msr_bitmap{vcpu->msr_bitmap()},
+    m_exit_handler{vcpu->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/main/arch/intel_x64/vcpu_factory.cpp
+++ b/src/main/arch/intel_x64/vcpu_factory.cpp
@@ -20,7 +20,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/arch/intel_x64/vcpu.h>
 
 namespace bfvmm
 {


### PR DESCRIPTION
- Move Intel vcpu code to live under hve
- Pass a single vcpu pointer to each exit handler
- Update relevant headers and sources to reflect the
  new vcpu paths